### PR TITLE
Affirm payload api endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,9 @@ rvm:
   - 2.3.1
 env:
   matrix:
-    - SOLIDUS_BRANCH=v1.1 DB=postgres
-    - SOLIDUS_BRANCH=v1.2 DB=postgres
-    - SOLIDUS_BRANCH=v1.3 DB=postgres
     - SOLIDUS_BRANCH=v1.4 DB=postgres
     - SOLIDUS_BRANCH=v2.0 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
-    - SOLIDUS_BRANCH=v1.1 DB=mysql
-    - SOLIDUS_BRANCH=v1.2 DB=mysql
-    - SOLIDUS_BRANCH=v1.3 DB=mysql
     - SOLIDUS_BRANCH=v1.4 DB=mysql
     - SOLIDUS_BRANCH=v2.0 DB=mysql
     - SOLIDUS_BRANCH=master DB=mysql

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ end
 
 gem 'pg'
 gem 'mysql2'
+gem 'jbuilder', github: 'rails/jbuilder'
 
 group :development, :test do
   gem "pry-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,18 @@
 source 'https://rubygems.org'
 
-gem 'solidus', github: 'solidusio/solidus', branch: ENV.fetch('SOLIDUS_BRANCH', 'master')
+branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
+gem 'solidus', github: 'solidusio/solidus', branch: branch
+
+if branch == 'master' || branch >= "v2.0"
+  gem "rails-controller-testing", group: :test
+end
 
 gem 'pg'
 gem 'mysql2'
 
 group :development, :test do
   gem "pry-rails"
+  gem 'rspec-activemodel-mocks'
 end
 
 gemspec

--- a/app/controllers/spree/api/affirm_controller.rb
+++ b/app/controllers/spree/api/affirm_controller.rb
@@ -1,7 +1,11 @@
 module Spree
   module Api
     class AffirmController < Spree::Api::BaseController
+      include Spree::Core::ControllerHelpers::Order
+      include Spree::Core::ControllerHelpers::Auth
+
       def payload
+        @order = current_order
       end
     end
   end

--- a/app/controllers/spree/api/affirm_controller.rb
+++ b/app/controllers/spree/api/affirm_controller.rb
@@ -1,0 +1,8 @@
+module Spree
+  module Api
+    class AffirmController < Spree::Api::BaseController
+      def payload
+      end
+    end
+  end
+end

--- a/app/views/spree/api/affirm/_address.json.jbuilder
+++ b/app/views/spree/api/affirm/_address.json.jbuilder
@@ -1,0 +1,14 @@
+json.name do
+  json.first address.first_name
+  json.last address.last_name
+end
+
+json.address do
+  json.line1 address.address1
+  json.city address.city
+  json.state address.state ? address.state.abbr : address.state_name
+  json.zipcode address.zipcode
+end
+
+json.phone_number address.phone
+json.email @order.email || @order.user.try!(:email)

--- a/app/views/spree/api/affirm/payload.json.jbuilder
+++ b/app/views/spree/api/affirm/payload.json.jbuilder
@@ -21,8 +21,10 @@ json.items @order.line_items do |line_item|
   json.qty line_item.quantity
   json.item_url spree.product_url(line_item.product)
 
-  if image = line_item.variant.images.first
-    json.item_image_url root_url + image.attachment.url
+  if item.variant.images.any?
+    json.item_image_url URI.join(root_url, item.variant.images.first.attachment.url(:large))
+  elsif item.variant.product.images.any?
+    json.item_image_url URI.join(root_url, item.variant.product.images.first.attachment.url(:large))
   end
 end
 

--- a/app/views/spree/api/affirm/payload.json.jbuilder
+++ b/app/views/spree/api/affirm/payload.json.jbuilder
@@ -10,7 +10,6 @@ end
 
 json.shipping do
   address = @order.ship_address
-
   json.name do
     json.first address.first_name
     json.last address.last_name
@@ -29,7 +28,6 @@ end
 
 json.billing do
   address = @order.bill_address
-
   json.name do
     json.first address.first_name
     json.last address.last_name

--- a/app/views/spree/api/affirm/payload.json.jbuilder
+++ b/app/views/spree/api/affirm/payload.json.jbuilder
@@ -1,0 +1,77 @@
+json.config do
+  json.financial_product_key Spree::Config.get(:affirm_financial_product_key)
+end
+
+json.merchant do
+  json.user_cancel_url cancel_affirm_url
+  json.user_confirmation_url confirm_affirm_url
+  json.user_confirmation_url_action "POST"
+end
+
+json.shipping do
+  address = @order.ship_address
+
+  json.name do
+    json.first address.first_name
+    json.last address.last_name
+  end
+
+  json.address do
+    json.line1 address.address1
+    json.city address.city
+    json.state address.state ? address.state.abbr : address.state_name
+    json.zipcode address.zipcode
+  end
+
+  json.phone_number address.phone
+  json.email @order.email || @order.user.try!(:email)
+end
+
+json.billing do
+  address = @order.bill_address
+
+  json.name do
+    json.first address.first_name
+    json.last address.last_name
+  end
+
+  json.address do
+    json.line1 address.address1
+    json.city address.city
+    json.state address.state ? address.state.abbr : address.state_name
+    json.zipcode address.zipcode
+  end
+
+  json.phone_number address.phone
+  json.email @order.email || @order.user.try!(:email)
+end
+
+json.items @order.line_items do |line_item|
+  json.display_name line_item.name
+  json.sku line_item.sku
+  json.unit_price line_item.price.to_money.cents
+  json.qty line_item.quantity
+  # This is shitty, the routing here is handled by angular
+  # and this is a required field, for reasons.
+  json.item_url spree_product_url(line_item.product)
+
+  if image = line_item.variant.images.first
+    json.item_image_url root_url + image.attachment.url
+  end
+end
+
+json.currency @order.currency
+json.order_id @order.number
+
+if !@order.promo_total.zero?
+  json.discounts do
+    json.promotions do
+      json.discount_amount @order.promo_total * -1
+      json.discount_display_name "Promotions & Discounts"
+    end
+  end
+end
+
+json.shipping_amount @order.shipment_total.to_money.cents
+json.tax_amount @order.tax_total.to_money.cents
+json.total @order.order_total_after_store_credit.to_money.cents

--- a/app/views/spree/api/affirm/payload.json.jbuilder
+++ b/app/views/spree/api/affirm/payload.json.jbuilder
@@ -51,8 +51,6 @@ json.items @order.line_items do |line_item|
   json.sku line_item.sku
   json.unit_price line_item.price.to_money.cents
   json.qty line_item.quantity
-  # This is shitty, the routing here is handled by angular
-  # and this is a required field, for reasons.
   json.item_url spree_product_url(line_item.product)
 
   if image = line_item.variant.images.first

--- a/app/views/spree/api/affirm/payload.json.jbuilder
+++ b/app/views/spree/api/affirm/payload.json.jbuilder
@@ -6,38 +6,12 @@ end
 
 json.shipping do
   address = @order.ship_address
-  json.name do
-    json.first address.first_name
-    json.last address.last_name
-  end
-
-  json.address do
-    json.line1 address.address1
-    json.city address.city
-    json.state address.state ? address.state.abbr : address.state_name
-    json.zipcode address.zipcode
-  end
-
-  json.phone_number address.phone
-  json.email @order.email || @order.user.try!(:email)
+  json.partial! 'address', address: address
 end
 
 json.billing do
   address = @order.bill_address
-  json.name do
-    json.first address.first_name
-    json.last address.last_name
-  end
-
-  json.address do
-    json.line1 address.address1
-    json.city address.city
-    json.state address.state ? address.state.abbr : address.state_name
-    json.zipcode address.zipcode
-  end
-
-  json.phone_number address.phone
-  json.email @order.email || @order.user.try!(:email)
+  json.partial! 'address', address: address
 end
 
 json.items @order.line_items do |line_item|

--- a/app/views/spree/api/affirm/payload.json.jbuilder
+++ b/app/views/spree/api/affirm/payload.json.jbuilder
@@ -1,6 +1,6 @@
-json.config do
-  json.financial_product_key Spree::Config.get(:affirm_financial_product_key)
-end
+# json.config do
+#   json.financial_product_key Spree::Config.get(:affirm_financial_product_key)
+# end
 
 json.merchant do
   json.user_cancel_url cancel_affirm_url
@@ -51,7 +51,7 @@ json.items @order.line_items do |line_item|
   json.sku line_item.sku
   json.unit_price line_item.price.to_money.cents
   json.qty line_item.quantity
-  json.item_url spree_product_url(line_item.product)
+  json.item_url spree.product_url(line_item.product)
 
   if image = line_item.variant.images.first
     json.item_image_url root_url + image.attachment.url

--- a/app/views/spree/api/affirm/payload.json.jbuilder
+++ b/app/views/spree/api/affirm/payload.json.jbuilder
@@ -21,10 +21,10 @@ json.items @order.line_items do |line_item|
   json.qty line_item.quantity
   json.item_url spree.product_url(line_item.product)
 
-  if item.variant.images.any?
-    json.item_image_url URI.join(root_url, item.variant.images.first.attachment.url(:large))
-  elsif item.variant.product.images.any?
-    json.item_image_url URI.join(root_url, item.variant.product.images.first.attachment.url(:large))
+  if line_item.variant.images.any?
+    json.item_image_url URI.join(root_url, line_item.variant.images.first.attachment.url(:large))
+  elsif line_item.variant.product.images.any?
+    json.item_image_url URI.join(root_url, line_item.variant.product.images.first.attachment.url(:large))
   end
 end
 

--- a/app/views/spree/api/affirm/payload.json.jbuilder
+++ b/app/views/spree/api/affirm/payload.json.jbuilder
@@ -1,7 +1,3 @@
-# json.config do
-#   json.financial_product_key Spree::Config.get(:affirm_financial_product_key)
-# end
-
 json.merchant do
   json.user_cancel_url cancel_affirm_url
   json.user_confirmation_url confirm_affirm_url

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,7 @@ Spree::Core::Engine.routes.draw do
       get :payload
     end
   end
+
+  post '/affirm/confirm', to: "affirm#confirm", as: :confirm_affirm
+  get '/affirm/cancel', to: "affirm#cancel", as: :cancel_affirm
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,7 @@
 Spree::Core::Engine.routes.draw do
-  # Add your extension routes here
+  namespace :api, defaults: { format: 'json' } do
+    resource :affirm, only: [], controller: 'affirm' do
+      get :payload
+    end
+  end
 end

--- a/solidus_affirm.gemspec
+++ b/solidus_affirm.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['test/**/*']
 
   s.add_dependency 'solidus', ['>= 1.1', '< 3']
+  s.add_dependency 'jbuilder'
 
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'poltergeist'

--- a/solidus_affirm.gemspec
+++ b/solidus_affirm.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", 'LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['test/**/*']
 
-  s.add_dependency 'solidus', ['>= 1.1', '< 3']
+  s.add_dependency 'solidus', ['>= 1.4', '< 3']
   s.add_dependency 'jbuilder'
 
   s.add_development_dependency 'capybara'

--- a/spec/controllers/spree/api/affirm_controller_spec.rb
+++ b/spec/controllers/spree/api/affirm_controller_spec.rb
@@ -21,7 +21,7 @@ module Spree
         expect(subject).to render_template("api/affirm/payload")
       end
 
-      it "renders the correct Affirm json payload" do
+      xit "renders the correct Affirm json payload" do
         subject
         expect(response).to be_success
         expect(response.body).to_not be_empty

--- a/spec/controllers/spree/api/affirm_controller_spec.rb
+++ b/spec/controllers/spree/api/affirm_controller_spec.rb
@@ -4,11 +4,17 @@ module Spree
   describe Api::AffirmController, type: :controller do
     render_views
 
+    let(:user) { create(:user) }
+    let(:current_api_user) { user }
+    let(:order) { create(:order_ready_to_complete, user: user) }
+
     before do
       stub_authentication!
     end
 
     describe "#payload" do
+      before { allow(controller).to receive(:current_order) { order } }
+
       it "renders the correct Affirm json payload" do
         get :payload, format: :json
         expect(response).to be_success

--- a/spec/controllers/spree/api/affirm_controller_spec.rb
+++ b/spec/controllers/spree/api/affirm_controller_spec.rb
@@ -13,10 +13,16 @@ module Spree
     end
 
     describe "#payload" do
+      subject { get :payload, format: :json }
+
       before { allow(controller).to receive(:current_order) { order } }
 
+      it "will render the jbuilder json template" do
+        expect(subject).to render_template("api/affirm/payload")
+      end
+
       it "renders the correct Affirm json payload" do
-        get :payload, format: :json
+        subject
         expect(response).to be_success
         expect(response.body).to_not be_empty
       end

--- a/spec/controllers/spree/api/affirm_controller_spec.rb
+++ b/spec/controllers/spree/api/affirm_controller_spec.rb
@@ -24,7 +24,18 @@ module Spree
       it "renders the correct Affirm json payload" do
         subject
         expect(response).to be_success
-        expect(response.body).to_not be_empty
+        expect(json_response).to_not be_empty
+
+        expect(json_response.key?("merchant")).to be_truthy
+        expect(json_response.key?("shipping")).to be_truthy
+        expect(json_response.key?("billing")).to be_truthy
+        expect(json_response.key?("items")).to be_truthy
+
+        expect(json_response["currency"]).to eql "USD"
+        expect(json_response["order_id"]).to eql order.number
+        expect(json_response["shipping_amount"]).to eql order.shipment_total.to_money.cents
+        expect(json_response["tax_amount"]).to eql order.tax_total.to_money.cents
+        expect(json_response["total"]).to eql order.order_total_after_store_credit.to_money.cents
       end
     end
   end

--- a/spec/controllers/spree/api/affirm_controller_spec.rb
+++ b/spec/controllers/spree/api/affirm_controller_spec.rb
@@ -21,7 +21,7 @@ module Spree
         expect(subject).to render_template("api/affirm/payload")
       end
 
-      xit "renders the correct Affirm json payload" do
+      it "renders the correct Affirm json payload" do
         subject
         expect(response).to be_success
         expect(response.body).to_not be_empty

--- a/spec/controllers/spree/api/affirm_controller_spec.rb
+++ b/spec/controllers/spree/api/affirm_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+module Spree
+  describe Api::AffirmController, type: :controller do
+    render_views
+    describe "#payload" do
+      it "renders the correct Affirm json payload" do
+        get :payload
+      end
+    end
+  end
+end

--- a/spec/controllers/spree/api/affirm_controller_spec.rb
+++ b/spec/controllers/spree/api/affirm_controller_spec.rb
@@ -12,6 +12,7 @@ module Spree
       it "renders the correct Affirm json payload" do
         get :payload, format: :json
         expect(response).to be_success
+        expect(response.body).to_not be_empty
       end
     end
   end

--- a/spec/controllers/spree/api/affirm_controller_spec.rb
+++ b/spec/controllers/spree/api/affirm_controller_spec.rb
@@ -3,9 +3,15 @@ require 'spec_helper'
 module Spree
   describe Api::AffirmController, type: :controller do
     render_views
+
+    before do
+      stub_authentication!
+    end
+
     describe "#payload" do
       it "renders the correct Affirm json payload" do
-        get :payload
+        get :payload, format: :json
+        expect(response).to be_success
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,8 @@ require 'spree/testing_support/controller_requests'
 require 'spree/testing_support/factories'
 require 'spree/testing_support/url_helpers'
 
+require 'spree/api/testing_support/helpers'
+
 # Requires factories defined in lib/solidus_affirm/factories.rb
 require 'solidus_affirm/factories'
 
@@ -46,6 +48,8 @@ RSpec.configure do |config|
   # visit spree.admin_path
   # current_path.should eql(spree.products_path)
   config.include Spree::TestingSupport::UrlHelpers
+  config.include Spree::TestingSupport::ControllerRequests, type: :controller
+  config.include Spree::Api::TestingSupport::Helpers, type: :controller
 
   # == Mock Framework
   #


### PR DESCRIPTION
This PR will provide an endpoint for rendering the expected json data in the javascript block that will be posted to Affirm. 

- [x] Setup api endpoint controller and action
- [x] Setup the needed configuration for confirm and cancel urls
- [x] Render the correct json using JBuilder
