### PR TITLE
Add Solidus 2.1 to Travis CI Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,12 @@ env:
     - SOLIDUS_BRANCH=v1.3 DB=postgres
     - SOLIDUS_BRANCH=v1.4 DB=postgres
     - SOLIDUS_BRANCH=v2.0 DB=postgres
+    - SOLIDUS_BRANCH=v2.1 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
     - SOLIDUS_BRANCH=v1.1 DB=mysql
     - SOLIDUS_BRANCH=v1.2 DB=mysql
     - SOLIDUS_BRANCH=v1.3 DB=mysql
     - SOLIDUS_BRANCH=v1.4 DB=mysql
     - SOLIDUS_BRANCH=v2.0 DB=mysql
+    - SOLIDUS_BRANCH=v2.1 DB=mysql
     - SOLIDUS_BRANCH=master DB=mysql


### PR DESCRIPTION
This extension is being tested against all the Solidus versions from 1.1
up to the current master. Since there will be a 2.1 version coming out
any time soon, master is on 2-2-alpha now. This PR makes sure that we
are actively testing this extension on Solidus 2.1 as well.