### PR TITLE
Affirm Payload with AMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ Bundle your dependencies and run the installation generator:
 bundle
 bundle exec rails g solidus_affirm:install
 ```
+## Configuration
+
+To generate the correct URL's in the JSON payload we need to specify the
+`default_url_options` for the Solidus engine. You can do that like this:
+
+```
+Spree::Core::Engine.routes.default_url_options = {
+  host: 'example.com'
+}
+```
 
 ## Testing
 

--- a/app/models/affirm/checkout_payload.rb
+++ b/app/models/affirm/checkout_payload.rb
@@ -1,0 +1,44 @@
+module Affirm
+  # This class represents the json payload needed for the Affirm checkout.
+  # It will escapsulate the +Spree::Order+ and the needed configuration and
+  # meta data that will be serialized and send as JSON to Affirm.
+  #
+  # @!attribute [r] order
+  #   [Spree::Order] The +Spree::Order+ instance that will be send to Affirm by
+  #   serializing this Object.
+  # @!attribute [r] config
+  #   [Hash] The configuration for Affirm, this hash expects the following keys:
+  #   +:user_confirmation_url+ and +:user_cancel_url+
+  #   and if you specify the optional +:name+ configuration, that will also be used.
+  # @!attribute [r] metadata
+  #   [Hash] Affirm support arbitrary key:value metadata, we pass this hash
+  #   directly to Affirm if it's present.
+  # @see CheckoutPayloadSerializer
+  class CheckoutPayload < ActiveModelSerializers::Model
+    attr_reader :order, :config, :metadata
+
+    # @param order [Spree::Order]
+    # @param config [Hash]
+    # @option config [String] :user_confirmation_url The redirect url for succesful Affirm checkout
+    # @option config [String] :user_cancel_url The redirect url for a canceled Affirm checkout
+    # @option config [String] :name The shop name to display in the Affirm checkout.
+    # @param metadata [Hash]
+    def initialize(order, config, metadata = {})
+      @order = order
+      @config = config
+      @metadata = metadata
+    end
+
+    def ship_address
+      order.ship_address
+    end
+
+    def bill_address
+      order.bill_address
+    end
+
+    def items
+      order.line_items
+    end
+  end
+end

--- a/app/serializers/affirm/address_serializer.rb
+++ b/app/serializers/affirm/address_serializer.rb
@@ -1,0 +1,25 @@
+require 'active_model_serializers'
+
+module Affirm
+  class AddressSerializer < ActiveModel::Serializer
+    attributes :name, :address
+
+    def name
+      {
+        first: object.firstname,
+        last: object.lastname
+      }
+    end
+
+    def address
+      {
+        line1: object.address1,
+        line2: object.address2,
+        city: object.city,
+        state: object.state.abbr,
+        zipcode: object.zipcode,
+        country: object.country.iso3
+      }
+    end
+  end
+end

--- a/app/serializers/affirm/checkout_payload_serializer.rb
+++ b/app/serializers/affirm/checkout_payload_serializer.rb
@@ -1,0 +1,66 @@
+require 'active_model_serializers'
+
+module Affirm
+  class CheckoutPayloadSerializer < ActiveModel::Serializer
+    attributes :merchant, :shipping, :billing, :items, :discounts, :metadata,
+    :order_id, :shipping_amount, :tax_amount, :total
+
+    def merchant
+      hsh = {
+        user_confirmation_url: object.config[:confirmation_url],
+        user_cancel_url: object.config[:cancel_url]
+      }
+      hsh[:name] = object.config[:name] if object.config[:name].present?
+      hsh
+    end
+
+    def shipping
+      Affirm::AddressSerializer.new(object.ship_address)
+    end
+
+    def billing
+      Affirm::AddressSerializer.new(object.bill_address)
+    end
+
+    def items
+      ActiveModel::Serializer::CollectionSerializer.new(
+        object.items,
+        serializer: Affirm::LineItemSerializer,
+        root: false
+      )
+    end
+
+    def discounts
+      promo_total = object.order.promo_total
+      if promo_total > 0
+        {
+          promotion_total: {
+            discount_amount: promo_total.to_money.cents,
+            discount_display_name: "Total promotion discount"
+          }
+        }
+      end
+    end
+
+    def order_id
+      object.order.number
+    end
+
+    def shipping_amount
+      object.order.shipment_total.to_money.cents
+    end
+
+    def tax_amount
+      object.order.tax_total.to_money.cents
+    end
+
+    def total
+      object.order.order_total_after_store_credit.to_money.cents
+    end
+
+    def metadata
+      return nil if object.metadata.empty?
+      object.metadata
+    end
+  end
+end

--- a/app/serializers/affirm/line_item_serializer.rb
+++ b/app/serializers/affirm/line_item_serializer.rb
@@ -1,0 +1,37 @@
+require 'active_model_serializers'
+
+module Affirm
+  class LineItemSerializer < ActiveModel::Serializer
+    attributes :display_name, :sku, :unit_price, :qty, :item_image_url, :item_url
+
+    def display_name
+      object.name
+    end
+
+    def unit_price
+      object.price.to_money.cents
+    end
+
+    def qty
+      object.quantity
+    end
+
+    def item_image_url
+      if object.variant.images.any?
+        object.variant.images.first.attachment.url(:large)
+      elsif object.variant.product.images.any?
+        object.variant.product.images.first.attachment.url(:large)
+      end
+    end
+
+    def item_url
+      spree_routes.product_url(object.product)
+    end
+
+    private
+
+    def spree_routes
+      Spree::Core::Engine.routes.url_helpers
+    end
+  end
+end

--- a/lib/solidus_affirm/engine.rb
+++ b/lib/solidus_affirm/engine.rb
@@ -8,13 +8,5 @@ module SolidusAffirm
     config.generators do |g|
       g.test_framework :rspec
     end
-
-    def self.activate
-      Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*_decorator*.rb')) do |c|
-        Rails.configuration.cache_classes ? require(c) : load(c)
-      end
-    end
-
-    config.to_prepare(&method(:activate).to_proc)
   end
 end

--- a/solidus_affirm.gemspec
+++ b/solidus_affirm.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['test/**/*']
 
   s.add_dependency 'solidus', ['>= 1.1', '< 3']
+  s.add_dependency 'active_model_serializers', '~> 0.10'
 
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'poltergeist'

--- a/spec/serializers/affirm/address_serializer_spec.rb
+++ b/spec/serializers/affirm/address_serializer_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+RSpec.describe Affirm::AddressSerializer do
+  let(:address) { create(:address, firstname: "John", lastname: "Do", zipcode: "58451") }
+  let(:serializer) { Affirm::AddressSerializer.new(address, root: false) }
+  subject { JSON.parse(serializer.to_json) }
+
+  describe "name" do
+    it "will be a composition with first -and lastname" do
+      name_json = { "first" => "John", "last" => "Do" }
+      expect(subject["name"]).to eql name_json
+    end
+  end
+
+  describe "address" do
+    it "will be a composition with the address fields" do
+      address_json = {
+        "line1" => "10 Lovely Street",
+        "line2" => "Northwest",
+        "city" => "Herndon",
+        "state" => "AL",
+        "zipcode" => "58451",
+        "country" => "USA"
+      }
+      expect(subject["address"]).to eql address_json
+    end
+  end
+end

--- a/spec/serializers/affirm/checkout_payload_serializer_spec.rb
+++ b/spec/serializers/affirm/checkout_payload_serializer_spec.rb
@@ -1,0 +1,170 @@
+require 'spec_helper'
+
+RSpec.describe Affirm::CheckoutPayloadSerializer do
+  let(:affirm_checkout_payload) { Affirm::CheckoutPayload.new(order, config, metadata) }
+  let(:serializer) { Affirm::CheckoutPayloadSerializer.new(affirm_checkout_payload, root: false) }
+  let(:line_item_attributes) do
+    [
+      { product: create(:product, name: 'awesome product', sku: "P1") },
+      { product: create(:product, name: 'amazing stuff', sku: "P2") }
+    ]
+  end
+  let(:shipping_address) { create(:ship_address, firstname: "John", lastname: "Do", zipcode: "52106-9133") }
+  let(:billing_address) { create(:bill_address, firstname: "John", lastname: "Do", zipcode: "58451") }
+
+  let(:order) do
+    create(:order_with_line_items,
+      line_items_count: 2,
+      line_items_attributes: line_item_attributes,
+      ship_address: shipping_address,
+      billing_address: billing_address)
+  end
+  let(:config) do
+    {
+      confirmation_url: "https://merchantsite.com/confirm",
+      cancel_url: "https://merchantsite.com/cancel"
+    }
+  end
+  let(:metadata) { {} }
+
+  subject { JSON.parse(serializer.to_json) }
+
+  it "wil have a 'merchant' object" do
+    merchant_json = {
+      "user_confirmation_url" => "https://merchantsite.com/confirm",
+      "user_cancel_url" => "https://merchantsite.com/cancel"
+    }
+    expect(subject['merchant']).to eql merchant_json
+  end
+
+  it "will have a 'shipping' object" do
+    shipping_json = {
+      "name" => { "first" => "John", "last" => "Do" },
+      "address" => {
+        "line1" => "A Different Road",
+        "line2" => "Northwest",
+        "city" => "Herndon",
+        "state" => "AL",
+        "zipcode" => "52106-9133",
+        "country" => "USA"
+      }
+    }
+    expect(subject['shipping']).to eql shipping_json
+  end
+
+  it "will have a 'billing' object" do
+    billing_json = {
+      "name" => { "first" => "John", "last" => "Do" },
+      "address" => {
+        "line1" => "PO Box 1337",
+        "line2" => "Northwest",
+        "city" => "Herndon",
+        "state" => "AL",
+        "zipcode" => "58451",
+        "country" => "USA"
+      }
+    }
+    expect(subject['billing']).to eql billing_json
+  end
+
+  it "will have an 'order_id'" do
+    expect(subject['order_id']).to eql order.number
+  end
+
+  it "will have a 'shipping_amount'" do
+    expect(subject['shipping_amount']).to eql 10_000
+  end
+
+  it "will have a 'tax_amount'" do
+    expect(subject['tax_amount']).to eql 0
+  end
+
+  it "will have a 'total'" do
+    expect(subject['total']).to eql 12_000
+  end
+
+  describe "merchant object" do
+    context "without an optional external name attribute" do
+      it "will not expose a name subject key" do
+        expect(subject['merchant']['user_confirmation_url']).to eql "https://merchantsite.com/confirm"
+        expect(subject['merchant']['user_cancel_url']).to eql "https://merchantsite.com/cancel"
+        expect(subject['merchant']['name']).to be_nil
+      end
+    end
+
+    context "with the optional external name attribute present" do
+      before do
+        config[:name] = "Your Customer-Facing Merchant Name"
+      end
+
+      it "will expose the name subject key" do
+        expect(subject['merchant']['user_confirmation_url']).to eql "https://merchantsite.com/confirm"
+        expect(subject['merchant']['user_cancel_url']).to eql "https://merchantsite.com/cancel"
+        expect(subject['merchant']['name']).to eql "Your Customer-Facing Merchant Name"
+      end
+    end
+  end
+
+  describe "items object" do
+    let(:items_json) do
+      [
+        {
+          "display_name" => "awesome product",
+          "sku" => "P1",
+          "unit_price" => 1000,
+          "qty" => 1,
+          "item_image_url" => nil,
+          "item_url" => "http://shop.localhost:3000/products/awesome-product"
+        },
+        {
+          "display_name" => "amazing stuff",
+          "sku" => "P2",
+          "unit_price" => 1000,
+          "qty" => 1,
+          "item_image_url" => nil,
+          "item_url" => "http://shop.localhost:3000/products/amazing-stuff"
+        }
+      ]
+    end
+
+    it "returns an array with the serialized line items" do
+      expect(subject["items"]).to eql items_json
+    end
+  end
+
+  describe 'discounts' do
+    context 'on an order without any promotions' do
+      it "will not render a discounts key" do
+        expect(subject['discounts']).to be_nil
+      end
+    end
+
+    context 'on an order with promotions' do
+      before do
+        expect(order).to receive(:promo_total).and_return(BigDecimal.new("100.00"))
+      end
+
+      it "will aggregate the promotions into the discounts key" do
+        output = subject
+        expect(output['discounts']).to_not be_empty
+        expect(output['discounts']['promotion_total']['discount_amount']).to eql 10_000
+        expect(output['discounts']['promotion_total']['discount_display_name']).to eql "Total promotion discount"
+      end
+    end
+  end
+
+  describe 'metadata' do
+    context 'when empty' do
+      it "will not expose the metadata key" do
+        expect(subject['metadata']).to be_nil
+      end
+    end
+
+    context 'any hash' do
+      let(:metadata) { { foo: 'bar' } }
+      it "will expose that hash directly at the metadata key" do
+        expect(subject['metadata']).to eql({ "foo" => "bar" })
+      end
+    end
+  end
+end

--- a/spec/serializers/affirm/line_item_serializer_spec.rb
+++ b/spec/serializers/affirm/line_item_serializer_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+RSpec.describe Affirm::LineItemSerializer do
+  let(:line_item) { create(:line_item, price: BigDecimal.new('14.99')) }
+  let(:serializer) { Affirm::LineItemSerializer.new(line_item, root: false) }
+  subject { JSON.parse(serializer.to_json) }
+
+  describe 'display_name' do
+    it "return the line_item variant name" do
+      expect(subject["display_name"]).to eql line_item.name
+    end
+  end
+
+  describe "unit_price" do
+    it "returns the line_item price in cents" do
+      expect(subject["unit_price"]).to eql 1_499
+    end
+  end
+
+  describe "qty" do
+    it "return the line_item quantity" do
+      expect(subject["qty"]).to eql 1
+    end
+  end
+
+  describe "item_image_url" do
+    context "with variant specific image" do
+      before do
+        expect(line_item.variant).to receive(:images).and_return([create(:image)]).twice
+      end
+
+      it "will return the variant image url" do
+        expect(subject['item_image_url']).to match /\/spree\/products\/\d\/large\/thinking-cat.jpg/
+      end
+    end
+
+    context "when the variant does not have an image" do
+      before do
+        expect(line_item.variant).to receive(:images).and_return([])
+        expect(line_item.variant.product).to receive(:images).and_return([create(:image)]).twice
+      end
+
+      it "will return the master product image url" do
+        expect(subject['item_image_url']).to match /\/spree\/products\/\d\/large\/thinking-cat.jpg/
+      end
+    end
+  end
+
+  describe "item_url" do
+    let(:product) { line_item.product }
+    let(:product_url) do
+      Spree::Core::Engine.routes.url_helpers.product_url(product)
+    end
+
+    it "is the url from the line_item product" do
+      expect(subject['item_url']).to eql product_url
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,10 @@ require 'spree/testing_support/url_helpers'
 # Requires factories defined in lib/solidus_affirm/factories.rb
 require 'solidus_affirm/factories'
 
+Spree::Core::Engine.routes.default_url_options = {
+  host: 'shop.localhost:3000'
+}
+
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
 
@@ -46,7 +50,6 @@ RSpec.configure do |config|
   # visit spree.admin_path
   # current_path.should eql(spree.products_path)
   config.include Spree::TestingSupport::UrlHelpers
-
   # == Mock Framework
   #
   # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:


### PR DESCRIPTION
This PR introduces a collection of ActiveModel Serializers to provide an
object oriented way for users to render the Affirm json payload for a
`Spree::Order` where needed.

It will also give them the possibility for easy overriding and
applying any needed customization without the need to open up the
classes by simply inherit from the Serializer and apply only the changes
needed.

- [x] 100% Spec coverage
- [x] line items image urls
- [x] discounts object with promotions
- [x] metadata rendering
- [x]  rebase / squash / split and rewrite commits