### PR TITLE
Update Rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 
 gem 'solidus', github: 'solidusio/solidus', branch: ENV.fetch('SOLIDUS_BRANCH', 'master')
 
-gem 'pg'
 gem 'mysql2'
+gem 'pg'
 
 group :development, :test do
   gem "pry-rails"

--- a/solidus_affirm.gemspec
+++ b/solidus_affirm.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_girl'
   s.add_development_dependency 'rspec-rails'
-  s.add_development_dependency 'rubocop', '0.37.2'
+  s.add_development_dependency 'rubocop', '>= 0.38'
   s.add_development_dependency 'rubocop-rspec', '1.4.0'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
The used rubocop version still had a deprecated `'last_comment'` call
that is now finally removed. This made the Rubocop Rake task fail hard
now though. This commit fixes that, by bumping Rubucop to `0.46.0`